### PR TITLE
use-env-resend-api-key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Example environment variables
+RESEND_API_KEY=

--- a/app/email/email-Query.tsx
+++ b/app/email/email-Query.tsx
@@ -1,8 +1,6 @@
 import { EmailTemplPw } from '../components/email-temp-Pw';
 import { EmailTemplate5 } from '../components/email-template5';
-import { Resend } from 'resend';
-
-const resend = new Resend(process.env.RESEND_API_KEY);
+import { resend } from './resend';
 
 //---------------------------------------------------------------------
 //------------------------1.1 Fonction email inscription  ------------

--- a/app/email/resend.tsx
+++ b/app/email/resend.tsx
@@ -1,4 +1,4 @@
 import { Resend } from 'resend';
 
-const resend = new Resend("re_NxZRa7bC_Q6DNSPB7y9fai8ZJLWAVrwYg");
+export const resend = new Resend(process.env.RESEND_API_KEY!);
 


### PR DESCRIPTION
## Summary
- remove inline Resend key
- export resend instance from env
- document `RESEND_API_KEY` example
- update email query to import the instance

## Testing
- `npm run lint` *(fails: next not found)*