### PR TITLE
Replace admin literals with env config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,5 @@
 # Example environment variables
 RESEND_API_KEY=
+ADMIN_EMAIL=
+ADMIN_ID_JEROME=
+ADMIN_ID_DEFAULT=

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ DATABASE_URL=<url de connexion PostgreSQL>
 SUPABASE_URL=<url du projet Supabase>
 SUPABASE_ANON_KEY=<clef anonyme Supabase>
 RESEND_API_KEY=<clef API Resend>
+# valeurs d'administration
+ADMIN_EMAIL=<email de l'administrateur>
+ADMIN_ID_JEROME=<identifiant administrateur principal>
+ADMIN_ID_DEFAULT=<identifiant utilisateur standard>
 # facultatif pour les emails
 VERCEL_URL=http://localhost:3000
 ```

--- a/app/components/form-CrmOuAdm_Connect.tsx
+++ b/app/components/form-CrmOuAdm_Connect.tsx
@@ -6,6 +6,7 @@ import CarteVImgTxtBgGN from "./cart-V-Img-Txt-BgGN";
 import ContBtnLgNoEffetBgG from "./cont-Btn-Lg-NoEffet-BgG";
 import { crmUserEmailAndPwSelection } from "../db/dbNeon-CrmUsers";
 import VarZustand from '../util/zustand';
+import { ADMIN_EMAIL, ADMIN_ID_JEROME, ADMIN_ID_DEFAULT } from "../util/admin-config";
 import Cookies from "js-cookie";
 import courrielPw from "../email/email-Pw";
 const FormSeConnecter: React.FC = () => {
@@ -33,13 +34,13 @@ const FormSeConnecter: React.FC = () => {
     console.log("2.0.1 ../../ Front FormConnect => useE => get Cookie =", cookieData);
 
     if (cookieData) {
-      if (cookieData.crmUserAdmin === "jerome1872Troistorrents") {
+      if (cookieData.crmUserAdmin === ADMIN_ID_JEROME) {
         console.log("2.0.2 ../../../ Front FormConnect => useE => get Cookie => set VarZustand & push ->/admin/users");
-        setUserAdmin("jerome1872Troistorrents");
+        setUserAdmin(ADMIN_ID_JEROME);
         router.push("/admin/users");
-      } else if (cookieData.crmUserAdmin === "user2025Nethelvetic") {
+      } else if (cookieData.crmUserAdmin === ADMIN_ID_DEFAULT) {
         console.log("2.0.3 ../../../ Front FormConnect => useE => get Cookie => set VarZustand & push ->/gestion360/identitfier");
-        setUserAdmin("user2025Nethelvetic");
+        setUserAdmin(ADMIN_ID_DEFAULT);
         router.push("/gestion360/identifier");
       } else {
         console.log("2.0.4 ../../../ Front FormConnect => useE => get Cookie => set VarZustand & push ->/formulaire/seConnecter");
@@ -88,10 +89,10 @@ const FormSeConnecter: React.FC = () => {
         Cookies.set('myData', JSON.stringify(myData), { expires: 1, path: '/' });
 
         //2.1.9 route push
-        if (crmUser.identification === "jerome1872Troistorrents") {
+        if (crmUser.identification === ADMIN_ID_JEROME) {
           console.log("2.1.9 ../../../../ Front FormConnect => H.S. => crmUserEmailAndPwSelect  => set Zustand/Cookies => Push -> admin/users");
           router.push("/admin/users");
-        } else if (crmUser.identification === "user2025Nethelvetic") {
+        } else if (crmUser.identification === ADMIN_ID_DEFAULT) {
           console.log("2.1.10 ../../../../ Front FormConnect => H.S. => crmUserEmailAndPwSelect  => set Zustand/Cookies => Push -> gestion360/identifier");
           //////////////////////////////////////////////////////////////////////
           //    CONTINUE A GESTION360/IDENTIFIER
@@ -111,7 +112,7 @@ const FormSeConnecter: React.FC = () => {
         // 2.1.11 set cookies
         const myData = {
           userJerome: "",
-          crmUserAdmin: crmUserEmailAndPwSelectRes.user?.email === "golliard73@gmail.com" ? "jerome1872Troistorrents": "user2025Nethelvetic",
+          crmUserAdmin: crmUserEmailAndPwSelectRes.user?.email === ADMIN_EMAIL ? ADMIN_ID_JEROME : ADMIN_ID_DEFAULT,
           crmUserImgUrl: crmUserEmailAndPwSelectRes.user?.imgUrl || "",
           crmUserAdminEmail: crmUserEmailAndPwSelectRes.user?.email || "",
           crmUserId: crmUserEmailAndPwSelectRes.user?.id || ""
@@ -141,8 +142,8 @@ const FormSeConnecter: React.FC = () => {
 
     // 2.2.2 set cookies
      const myData = {
-       userJerome: username === "golliard73@gmail.com" ? "jerome1872Troistorrents": "user2025Nethelvetic",
-       crmUserAdmin: username === "golliard73@gmail.com" ? "jerome1872Troistorrents": "user2025Nethelvetic",
+       userJerome: username === ADMIN_EMAIL ? ADMIN_ID_JEROME : ADMIN_ID_DEFAULT,
+       crmUserAdmin: username === ADMIN_EMAIL ? ADMIN_ID_JEROME : ADMIN_ID_DEFAULT,
        crmUserImgUrl: "",
        crmUserAdminEmail: username || "",
        crmUserId: "",

--- a/app/components/form-CrmUser_Inscrit.tsx
+++ b/app/components/form-CrmUser_Inscrit.tsx
@@ -8,6 +8,7 @@ import courrielInscription from "../email/crmUser_EmailInscrit";
 import { crmUserInsertion} from "../db/dbNeon-CrmUserInscrit"; 
 import VarZustand from "../util/zustand";
 import Cookies from "js-cookie";
+import { ADMIN_EMAIL, ADMIN_ID_JEROME, ADMIN_ID_DEFAULT } from "../util/admin-config";
 
 type UserDataType = {
   nom_entreprise?: string;
@@ -181,14 +182,14 @@ const  FormCrmUserIns: React.FC = () => {
             
                 //------------------------------------------------------------
                 // 2.2.9 ../../../ FRONT CrmUser-Form => H.S. => crmUser-Pw  => CrmUser-Ins => set Zust/coock  email = golliard73@g
-                if (userObj.email === "golliard73@gmail.com") {
+                if (userObj.email === ADMIN_EMAIL) {
                   console.log(" 2.2.9 ../../../ FRONT CrmUser-Form => H.S. => crmUser-Pw  => CrmUser-Ins => set Zust/coock >golliard73@g");
-                
-                  setUserAdmin("jerome1872Troistorrents")
+
+                  setUserAdmin(ADMIN_ID_JEROME)
 
                   const myCookieData = {
-                    userJerome: "jerome1872Troistorrents",
-                    crmUserAdmin: "jerome1872Troistorrents",  
+                    userJerome: ADMIN_ID_JEROME,
+                    crmUserAdmin: ADMIN_ID_JEROME,
                     crmUserImgUrl: userObj.imgUrl,
                     crmUserAdminEmail: username,  
                     crmUserId: userObj.id           
@@ -208,7 +209,7 @@ const  FormCrmUserIns: React.FC = () => {
                 
                   const myCookieData = {
                     userJerome: "false",
-                    crmUserAdmin: "user2025Nethelvetic",  
+                    crmUserAdmin: ADMIN_ID_DEFAULT,
                     crmUserImgUrl: userObj.imgUrl, 
                     crmUserAdminEmail: username, 
                     crmUserId: userObj.id           

--- a/app/components/form-Init-Pw.tsx
+++ b/app/components/form-Init-Pw.tsx
@@ -7,6 +7,7 @@ import CarteVImgTxtBgGN from "./cart-V-Img-Txt-BgGN";
 import ContBtnLgNoEffetBgG from "./cont-Btn-Lg-NoEffet-BgG";
 import { crmUserInsertion} from "../db/dbNeon-CrmUserInscrit";
 import VarZustand from "../util/zustand";
+import { ADMIN_EMAIL, ADMIN_ID_JEROME, ADMIN_ID_DEFAULT } from "../util/admin-config";
 
 const FormInitPw: React.FC = () => {
   //---------------------------------------------------------------------
@@ -106,14 +107,14 @@ const FormInitPw: React.FC = () => {
         console.log("2.2.6 FormInitPw h.s. => Inscri SUCCES => set Zustand & cookies");
         const userObj = Array.isArray(res.user) ? res.user[0] : res.user;
 
-        if (userObj.email === "golliard73@gmail.com") {
+        if (userObj.email === ADMIN_EMAIL) {
           console.log("2.2.7 Front FormInitPw h.s. => Inscri SUCCES => admin golliard");
-          setUserAdmin("jerome1872Troistorrents");
+          setUserAdmin(ADMIN_ID_JEROME);
           Cookies.set(
             'myData',
             JSON.stringify({
-              userJerome: "jerome1872Troistorrents",
-              crmUserAdmin: "jerome1872Troistorrents",
+              userJerome: ADMIN_ID_JEROME,
+              crmUserAdmin: ADMIN_ID_JEROME,
               crmUserImgUrl: userObj.imgUrl,
               crmUserAdminEmail: username,
               crmUserId: userObj.id ?? ""
@@ -128,7 +129,7 @@ const FormInitPw: React.FC = () => {
             'myData',
             JSON.stringify({
               userJerome: "false",
-              crmUserAdmin: "user2025Nethelvetic",
+              crmUserAdmin: ADMIN_ID_DEFAULT,
               crmUserImgUrl: userObj.imgUrl,
               crmUserAdminEmail: username,
               crmUserId: userObj.id ?? ""

--- a/app/components/li-CrmUser_usersBtn-bgGN.tsx
+++ b/app/components/li-CrmUser_usersBtn-bgGN.tsx
@@ -5,6 +5,7 @@ import ContainerBgGN from './cont-BgGN';
 import { useRouter } from "next/navigation";
 import ContBtnLgNoEffectBgG from './cont-Btn-Lg-NoEffet-BgG';
 import Cookies from "js-cookie";
+import { ADMIN_ID_DEFAULT } from "../util/admin-config";
 
 interface CarteData {
   id: number;
@@ -76,7 +77,7 @@ const ListCrmUser_userBtnBgGN: React.FC<ListCrmUser_userBtnBgGNProps> = ({
            //2.1.8 set cookies
           const myData = {
             userJerome: "false",
-            crmUserAdmin: "user2025Nethelvetic",
+            crmUserAdmin: ADMIN_ID_DEFAULT,
             crmUserImgUrl: card.imgUrl,
             crmUserAdminEmail: card.email,
             crmUserId: card.id

--- a/app/components/li-Users-btn-bgGN.tsx
+++ b/app/components/li-Users-btn-bgGN.tsx
@@ -5,6 +5,7 @@ import ContainerBgGN from './cont-BgGN';
 import { useRouter } from "next/navigation";
 import ContBtnLgNoEffectBgG from './cont-Btn-Lg-NoEffet-BgG';
 import Cookies from "js-cookie";
+import { ADMIN_ID_DEFAULT } from "../util/admin-config";
 
 interface CarteData {
   id: number;
@@ -78,7 +79,7 @@ const ListHUsersBtnBgGN: React.FC<ListHUsersBtnBgGNProps> = ({
            //2.1.8 set cookies
           const myData = {
             userJerome: "false",
-            crmUserAdmin: "user2025Nethelvetic",
+            crmUserAdmin: ADMIN_ID_DEFAULT,
             crmUserImgUrl: card.imgUrl,
             crmUserAdminEmail: card.email,
             crmUserId: card.id

--- a/app/components/navBar-H.tsx
+++ b/app/components/navBar-H.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useEffect } from "react";
 import Cookies from "js-cookie";
 import VarZustand from "../util/zustand";
+import { ADMIN_ID_JEROME } from "../util/admin-config";
 
 interface NavSubItem {
   title: string;
@@ -99,7 +100,7 @@ const NavBarH: React.FC<NavBarHProps> = ({ items, logo }) => {
             </a>
           ) : (
             <>
-              {userAdmin === "jerome1872Troistorrents" ? (
+              {userAdmin === ADMIN_ID_JEROME ? (
                 // --- si c'est Jerome, on ne change rien (on pourrait afficher un avatar ou un label spécial) ---
                 <div className="flex items-center gap-2">
                   {/* ici on laisse tel quel / ou mettre un avatar/admin placeholder */}
@@ -194,7 +195,7 @@ const NavBarH: React.FC<NavBarHProps> = ({ items, logo }) => {
           >
             Connecter
           </a>
-        ) : userAdmin === "jerome1872Troistorrents" ? (
+        ) : userAdmin === ADMIN_ID_JEROME ? (
           // mobile, Jerome : rien à changer non plus
           <button
             onClick={handleLogout}

--- a/app/components/p-CrmUser_userBtnM.tsx
+++ b/app/components/p-CrmUser_userBtnM.tsx
@@ -7,6 +7,7 @@ import BtnLgNoEffetBgG from "./btn-Lg-NoEf-Url-BgG";
 import LiCrmUser_userBtnBgGN from "./li-CrmUser_usersBtn-bgGN";
 import Cookies from "js-cookie";
 import { useRouter } from "next/navigation";
+import { ADMIN_ID_JEROME, ADMIN_ID_DEFAULT } from "../util/admin-config";
 
 const PageCrmUser_userBtnM: React.FC = () => {
   //---------------------------------------------------------------------
@@ -57,7 +58,7 @@ const PageCrmUser_userBtnM: React.FC = () => {
 
      //---------------------------------------------------------------------
     //2.0.6 ../../../.?/ gest360CrmUser => useEf => cookies => parse Cookie => get userAdmin2
-    if (cookieData.crmUserAdmin === "jerome1872Troistorrents") {
+    if (cookieData.crmUserAdmin === ADMIN_ID_JEROME) {
       console.log("2.0.6 ../../../../ FRONT PageCrmUser_user => useEf => cookies => parse Cookie => get userAdmin2 & push admin/user: ", cookieData.crmUserAdmin );
       router.push("/admin/users");
       ///////////////////////////////////////////////////////////////////
@@ -67,7 +68,7 @@ const PageCrmUser_userBtnM: React.FC = () => {
 
       //---------------------------------------------------------------------
       //2.0.7 ../../.?/ gest360CrmUser => useEffect => cookies OK => parse Cookie => get userAdmin1
-    } else if (cookieData.crmUserAdmin === "user2025Nethelvetic") {
+    } else if (cookieData.crmUserAdmin === ADMIN_ID_DEFAULT) {
       // Utilisateur normal : on reste ici, on ne fait rien
       console.log("2.0.7 ../../../../ FRONT PageCrmUser_user => useE => cookies => parse Cookie => userAdmin1 OK", cookieData.crmUserAdmin);;
       ///////////////////////////////////////////////////////////////////

--- a/app/db/dbNeon.tsx
+++ b/app/db/dbNeon.tsx
@@ -3,6 +3,7 @@ import { neon } from '@neondatabase/serverless';
 import { drizzle } from "drizzle-orm/neon-http";
 import { and, eq, isNotNull, not } from "drizzle-orm";
 import { formationTable, evenementsTable, usersTable, messageTable, crmUsersTable, crmUser_UsersTable  } from "./schema";
+import { ADMIN_EMAIL, ADMIN_ID_JEROME, ADMIN_ID_DEFAULT } from "../util/admin-config";
 
 
 // 105  TABLES FORMATION
@@ -1346,7 +1347,7 @@ export async function crmUserInscrit(user: FormatUserInput, crmMotdePasse: strin
         status_abonnement: "actif",
         status_paiement: "non payé",
         mot_de_passe:  crmMotdePasse,
-        identification: user.email  === "golliard73@gmail.com"? "jerome1872Troistorrents": "user2025Nethelvetic",
+        identification: user.email  === ADMIN_EMAIL ? ADMIN_ID_JEROME : ADMIN_ID_DEFAULT,
         userId: existingUser[0].id,
       };
 
@@ -1445,7 +1446,7 @@ export async function crmUserInscrit(user: FormatUserInput, crmMotdePasse: strin
           status_abonnement: "actif",
           status_paiement: "non payé",
           mot_de_passe: crmMotdePasse,
-          identification: user.email  === "golliard73@gmail.com"? "jerome1872Troistorrents": "user2025Nethelvetic",
+          identification: user.email  === ADMIN_EMAIL ? ADMIN_ID_JEROME : ADMIN_ID_DEFAULT,
           userId: userInserted[0].id,
         };
         const crmUserInsertRes = await crmUserInsert(crmData);

--- a/app/db/dbSupabase.tsx
+++ b/app/db/dbSupabase.tsx
@@ -10,6 +10,7 @@ import {
 } from "./schema";
 import { drizzle } from "drizzle-orm/postgres-js";
 import { and, eq, isNotNull, not } from "drizzle-orm";
+import { ADMIN_EMAIL, ADMIN_ID_JEROME, ADMIN_ID_DEFAULT } from "../util/admin-config";
 import postgres from "postgres";
 
 //------------------------------------------------------------------------
@@ -271,9 +272,9 @@ export async function crmUserInscrit(user: FormatUserInput, crmMotdePasse: strin
         status_abonnement:      "actif",
         status_paiement:        "non payé",
         mot_de_passe:           crmMotdePasse,
-        identification:         user.email === "golliard73@gmail.com"
-                                  ? "jerome1872Troistorrents"
-                                  : "user2025Nethelvetic",
+        identification:         user.email === ADMIN_EMAIL
+                                  ? ADMIN_ID_JEROME
+                                  : ADMIN_ID_DEFAULT,
         userId: existingUser[0].id,
       };
       const crmUserInsertRes = await crmUserInsert(crmDataForExistingUser);
@@ -324,9 +325,9 @@ export async function crmUserInscrit(user: FormatUserInput, crmMotdePasse: strin
           status_abonnement:      "actif",
           status_paiement:        "non payé",
           mot_de_passe:           crmMotdePasse,
-          identification:         user.email === "golliard73@gmail.com"
-                                    ? "jerome1872Troistorrents"
-                                    : "user2025Nethelvetic",
+          identification:         user.email === ADMIN_EMAIL
+                                    ? ADMIN_ID_JEROME
+                                    : ADMIN_ID_DEFAULT,
           userId: userInserted[0].id,
         };
         const crmUserInsertRes2 = await crmUserInsert(crmData);

--- a/app/db/schema.tsx
+++ b/app/db/schema.tsx
@@ -1,12 +1,13 @@
-import { 
-  integer, 
-  pgTable, 
-  varchar, 
-  date, 
-  text, 
+import {
+  integer,
+  pgTable,
+  varchar,
+  date,
+  text,
   json,
 } from "drizzle-orm/pg-core";
 import { sql as drizzleSql, relations } from "drizzle-orm";
+import { ADMIN_ID_JEROME } from "../util/admin-config";
 
 // --------------------------------------------------------------------
 // --------------------------------------------------------------------
@@ -167,7 +168,7 @@ export const crmUsersTable = pgTable("crmUsers", {
   status_paiement: varchar({ length: 50 }).notNull().default("non payé"),
   mode_paiement: varchar({ length: 100 }),
   facturation_info: text(),
-  identification: varchar({ length: 50 }).notNull().default("jerome1872Troistorrents"),
+  identification: varchar({ length: 50 }).notNull().default(ADMIN_ID_JEROME),
   userId: integer().references(() => usersTable.id, { onDelete: "cascade" }),
 });
 

--- a/app/email/email-Query.tsx
+++ b/app/email/email-Query.tsx
@@ -1,6 +1,7 @@
 import { EmailTemplPw } from '../components/email-temp-Pw';
 import { EmailTemplate5 } from '../components/email-template5';
 import { resend } from './resend';
+import { ADMIN_EMAIL } from '../util/admin-config';
 
 //---------------------------------------------------------------------
 //------------------------1.1 Fonction email inscription  ------------
@@ -15,7 +16,7 @@ export async function crmUser_EmailInscrit(emailProps: string) {
 
     const { data, error } = await resend.emails.send({
       from: 'Nethelvetic <do-not-reply@test.nethelvetic.ch>',
-      to: ['golliard73@gmail.com'],
+      to: [ADMIN_EMAIL],
       subject: 'Hello world',
       react: reactContent,
     });
@@ -48,7 +49,7 @@ export async function emailPw(emailProps: string) {
 
     const { data, error } = await resend.emails.send({
       from: 'Nethelvetic <do-not-reply@test.nethelvetic.ch>',
-      to: ['golliard73@gmail.com'],
+      to: [ADMIN_EMAIL],
       subject: 'Hello world',
       react: reactContent,
     });

--- a/app/util/admin-config.ts
+++ b/app/util/admin-config.ts
@@ -1,0 +1,3 @@
+export const ADMIN_EMAIL = process.env.ADMIN_EMAIL || 'golliard73@gmail.com';
+export const ADMIN_ID_JEROME = process.env.ADMIN_ID_JEROME || 'jerome1872Troistorrents';
+export const ADMIN_ID_DEFAULT = process.env.ADMIN_ID_DEFAULT || 'user2025Nethelvetic';


### PR DESCRIPTION
## Summary
- externalise admin identifiers and email in `admin-config`
- reference env constants in forms, navbar and emails
- apply same logic to DB helpers and schema
- document new environment variables

## Testing
- `npm run lint` *(fails: next not found)*