### PR TITLE
Set default tab to infos

### DIFF
--- a/app/components/form-CrmUser_user.tsx
+++ b/app/components/form-CrmUser_user.tsx
@@ -61,7 +61,7 @@ const FormCrmUser_user: React.FC = () => {
   //---------------------------------------------------------------------
   const [unUserData, setUnUserData] = useState<UserDataType>(initialUserData);
   const [activeTab, setActiveTab] =
-    useState<"factures" | "offres" | "infos">("factures");
+    useState<"factures" | "offres" | "infos">("infos");
   const { userId } = useParams();
   const userIdStr = Array.isArray(userId) ? userId[0] : userId;
   const getInputClass = (value: string) =>


### PR DESCRIPTION
## Notes
- The project doesn't have its node modules installed, so `npm run lint` fails with `next: not found`.

## Summary
- show the contact info tab first for a selected CRM user