### PR TITLE
Fix CRM mini form image height and add company field

### DIFF
--- a/app/components/form-CrmUser_user.tsx
+++ b/app/components/form-CrmUser_user.tsx
@@ -111,7 +111,7 @@ const FormCrmUser_user: React.FC = () => {
   const MiniUserForm = () => (
     <form className="space-y-4 p-4 w-full">
       <div className="flex flex-col md:flex-row items-start md:items-stretch p-3">
-        <div className="w-full md:w-1/3 mx-auto md:mx-0 flex flex-col h-80 md:h-full overflow-hidden">
+        <div className="w-full md:w-1/3 mx-auto md:mx-0 flex flex-col h-80 md:h-104 overflow-hidden">
           <div className="w-full overflow-hidden mt-15">
             <img
               src={unUserData.imgUrl}
@@ -130,6 +130,16 @@ const FormCrmUser_user: React.FC = () => {
                 setUnUserData({ ...unUserData, email: e.target.value })
               }
               className={`w-full border-b ${getInputClass(unUserData.email)}`}
+            />
+          </div>
+          <div>
+            <label>Nom de l'entreprise</label>
+            <input
+              value={unUserData.nom_entreprise}
+              onChange={e =>
+                setUnUserData({ ...unUserData, nom_entreprise: e.target.value })
+              }
+              className={`w-full border-b ${getInputClass(unUserData.nom_entreprise)}`}
             />
           </div>
           <div>


### PR DESCRIPTION
## Summary
- sync left image height with the form for Factures/Offres tabs
- show company name field in mini CRM user form

## Testing
- `npm run lint` *(fails: `next` not found)*