### PR TITLE
Align width of crm info form on mobile

### DIFF
--- a/app/components/CrmUser_userInfosNoImg.tsx
+++ b/app/components/CrmUser_userInfosNoImg.tsx
@@ -97,7 +97,7 @@ const CrmUser_userInfosNoImg: React.FC<CrmUserUserInfosProps> = ({ userData, set
   }
 
   return (
-    <div className="p-6 space-y-6">
+    <div className="p-6 space-y-6 max-w-5xl mx-auto">
 
       <ContainerBGN>
         <div className="w-full">

--- a/app/components/form-CrmUser_user.tsx
+++ b/app/components/form-CrmUser_user.tsx
@@ -8,6 +8,7 @@ import CrmUser_userFactures from "./CrmUser_userFactures";
 import CrmUser_userOffre from "./CrmUser_userOffre";
 import CrmUser_userInfosFull from "./CrmUser_userInfosFull";
 import CrmUser_userInfosSimple from "./crmUser_userInfosSimple";
+import CrmUser_userInfosNoImg from "./CrmUser_userInfosNoImg";
 
 // TypeScript interface reprenant la structure du formulaire de modification
 interface UserDataType {
@@ -199,11 +200,20 @@ const FormCrmUser_user: React.FC = () => {
               {activeTab === "infos" && (
                 <>
                   <MiniUserForm />
-                  <CrmUser_userInfosFull
-                    key={unUserData.userId}
-                    userData={unUserData}
-                    setUserData={setUnUserData}
-                  />
+                  <div className="block md:hidden">
+                    <CrmUser_userInfosNoImg
+                      key={unUserData.userId}
+                      userData={unUserData}
+                      setUserData={setUnUserData}
+                    />
+                  </div>
+                  <div className="hidden md:block">
+                    <CrmUser_userInfosFull
+                      key={unUserData.userId}
+                      userData={unUserData}
+                      setUserData={setUnUserData}
+                    />
+                  </div>
                 </>
               )}
             </div>


### PR DESCRIPTION
## Summary
- import mobile friendly contact info form
- render `CrmUser_userInfosNoImg` on small screens
- ensure `CrmUser_userInfosNoImg` container matches width of `MiniUserForm`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683efe266a448327b7fb129a880be109