### PR TITLE
Fix dev recompilation loop

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -17,8 +17,8 @@ const nextConfig: NextConfig = {
       poll: 500,
       // attendre 200 ms après un changement pour lancer la recompilation
       aggregateTimeout: 200,
-      // on peut ignorer node_modules pour éviter trop de bruit
-      ignored: /node_modules/,
+      // on peut ignorer node_modules et .next pour éviter trop de bruit
+      ignored: /node_modules|\.next/,
     };
     return config;
   },


### PR DESCRIPTION
## Summary
- ignore `.next` directory in the dev server polling config

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68404db2159483279d80d52c43427dbf